### PR TITLE
Fix building of gcc in cross-tools for powerpc multilib.

### DIFF
--- a/BOOK/cross-tools/ppc64-chapter.xml
+++ b/BOOK/cross-tools/ppc64-chapter.xml
@@ -22,9 +22,9 @@
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common/mpc.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="common/isl.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="multilib/binutils.xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="multilib/gcc-static.xml"/>
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ppc64/gcc-static.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="multilib/glibc.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="multilib/glibc-64bit.xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="multilib/gcc-final.xml"/>
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ppc64/gcc-final.xml"/>
 
 </chapter>

--- a/BOOK/cross-tools/ppc64/gcc-final.xml
+++ b/BOOK/cross-tools/ppc64/gcc-final.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE sect1 PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+  "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+  <!ENTITY % general-entities SYSTEM "../../general.ent">
+  %general-entities;
+]>
+
+<sect1 id="ch-cross-tools-gcc-final" role="wrap">
+  <?dbhtml filename="gcc-final.html"?>
+
+  <title>Cross GCC-&gcc-version; - Final</title>
+
+  <indexterm zone="ch-cross-tools-gcc-final">
+    <primary sortas="a-GCC">GCC</primary>
+    <secondary>cross tools, final</secondary>
+  </indexterm>
+
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+  href="../../final-system/common/gcc.xml"
+  xpointer="xpointer(//*[@role='package'])"/>
+
+  <sect2 role="installation">
+    <title>Installation of GCC Cross Compiler</title>
+
+<!--GCC Branch Update Area
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="../../final-system/common/gcc.xml"
+    xpointer="xpointer(//*[@os='p1'])"/>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="../../final-system/common/gcc.xml"
+    xpointer="xpointer(//*[@os='p2'])"/>
+-->
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="gcc-static.xml"
+    xpointer="xpointer(//*[@os='aa'])"/>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="gcc-static.xml"
+    xpointer="xpointer(//*[@os='ab'])"/>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="gcc-static.xml"
+    xpointer="xpointer(//*[@os='ag'])"/>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="gcc-static.xml"
+    xpointer="xpointer(//*[@os='ah'])"/>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="gcc-static.xml"
+    xpointer="xpointer(//*[@os='f'])"/>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="gcc-static.xml"
+    xpointer="xpointer(//*[@os='g'])"/>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="gcc-static.xml"
+    xpointer="xpointer(//*[@os='h'])"/>
+
+<screen os="bf"><userinput>AR=ar \
+LDFLAGS="-Wl,-rpath,/cross-tools/lib" \
+../gcc-&gcc-version;/configure \
+    --prefix=/cross-tools \
+    --build=${CLFS_HOST} \
+    --target=${CLFS_TARGET} \
+    --host=${CLFS_HOST} \
+    --with-sysroot=${CLFS} \
+    --with-local-prefix=/tools \
+    --with-native-system-header-dir=/tools/include \
+    --disable-static \
+    --enable-languages=c,c++ \
+    --with-mpc=/cross-tools \
+    --with-mpfr=/cross-tools \
+    --with-gmp=/cross-tools \
+    --with-isl=/cross-tools</userinput></screen>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="../common/gcc-final.xml"
+    xpointer="xpointer(//*[@os='bg'])"/>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="../common/gcc-final.xml"
+    xpointer="xpointer(//*[@os='bh'])"/>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="../common/gcc-final.xml"
+    xpointer="xpointer(//*[@os='bi'])"/>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="../common/gcc-final.xml"
+    xpointer="xpointer(//*[@os='bj'])"/>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="../common/gcc-final.xml"
+    xpointer="xpointer(//*[@os='bk'])"/>
+
+  </sect2>
+
+  <sect2 role="content">
+    <title/>
+
+    <para>Details on this package are located in <xref
+    linkend="contents-gcc" role="."/></para>
+
+  </sect2>
+
+</sect1>

--- a/BOOK/cross-tools/ppc64/gcc-static.xml
+++ b/BOOK/cross-tools/ppc64/gcc-static.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE sect1 PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+  "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+  <!ENTITY % general-entities SYSTEM "../../general.ent">
+  %general-entities;
+]>
+
+<sect1 id="ch-cross-tools-gcc-static" role="wrap">
+  <?dbhtml filename="gcc-static.html"?>
+
+  <title>Cross GCC-&gcc-version; - Static</title>
+
+  <indexterm zone="ch-cross-tools-gcc-static">
+    <primary sortas="a-GCC">GCC</primary>
+    <secondary>cross tools, static</secondary>
+  </indexterm>
+
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+  href="../../final-system/common/gcc.xml"
+  xpointer="xpointer(//*[@role='package'])"/>
+
+  <sect2 role="installation">
+    <title>Installation of Cross GCC Compiler with Static libgcc
+    and no Threads</title>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="../common/gcc-static.xml"
+    xpointer="xpointer(//*[@os='e'])"/>
+
+<!--GCC Branch Update Area
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="../../final-system/common/gcc.xml"
+    xpointer="xpointer(//*[@os='p1'])"/>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="../../final-system/common/gcc.xml"
+    xpointer="xpointer(//*[@os='p2'])"/>
+-->
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="../common/gcc-static.xml"
+    xpointer="xpointer(//*[@os='aa'])"/>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="../common/gcc-static.xml"
+    xpointer="xpointer(//*[@os='ab'])"/>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="../common/gcc-static.xml"
+    xpointer="xpointer(//*[@os='ag'])"/>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="../ppc/gcc-static.xml"
+    xpointer="xpointer(//*[@os='ah'])"/>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="../common/gcc-static.xml"
+    xpointer="xpointer(//*[@os='t1'])"/>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="../common/gcc-static.xml"
+    xpointer="xpointer(//*[@os='t2'])"/>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="../../final-system/common/gcc.xml"
+    xpointer="xpointer(//*[@os='f'])"/>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="../../final-system/common/gcc.xml"
+    xpointer="xpointer(//*[@os='g'])"/>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="../../final-system/common/gcc.xml"
+    xpointer="xpointer(//*[@os='h'])"/>
+
+<screen os="al"><userinput>AR=ar \
+LDFLAGS="-Wl,-rpath,/cross-tools/lib" \
+../gcc-&gcc-version;/configure \
+    --prefix=/cross-tools \
+    --build=${CLFS_HOST} \
+    --host=${CLFS_HOST} \
+    --target=${CLFS_TARGET} \
+    --with-sysroot=${CLFS} \
+    --with-local-prefix=/tools \
+    --with-native-system-header-dir=/tools/include \
+    --disable-shared \
+    --with-mpfr=/cross-tools \
+    --with-gmp=/cross-tools \
+    --with-isl=/cross-tools \
+    --with-mpc=/cross-tools \
+    --without-headers \
+    --with-newlib \
+    --disable-decimal-float \
+    --disable-libgomp \
+    --disable-libssp \
+    --disable-libatomic \
+    --disable-libitm \
+    --disable-libsanitizer \
+    --disable-libquadmath \
+    --disable-libvtv \
+    --disable-libcilkrts \
+    --disable-libstdc++-v3 \
+    --disable-threads \
+    --disable-nls \
+    --disable-libmpx \
+    --enable-languages=c \
+    --with-glibc-version=&glibc-version;</userinput></screen>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="../common/gcc-static.xml"
+    xpointer="xpointer(//*[@os='am'])"/>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="../common/gcc-static.xml"
+    xpointer="xpointer(//*[@os='an'])"/>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="../common/gcc-static.xml"
+    xpointer="xpointer(//*[@os='ao'])"/>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="../common/gcc-static.xml"
+    xpointer="xpointer(//*[@os='ap'])"/>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="../common/gcc-static.xml"
+    xpointer="xpointer(//*[@os='aq'])"/>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+    href="../common/gcc-static.xml"
+    xpointer="xpointer(//*[@os='ar'])"/>
+
+  </sect2>
+
+  <sect2 role="content">
+    <title/>
+
+    <para>Details on this package are located in <xref
+    linkend="contents-gcc" role="."/></para>
+
+  </sect2>
+
+</sect1>


### PR DESCRIPTION
This is a partial fix of ticket #933.

For powerpc cross gcc, the STANDARD_STARTFILE_PREFIX changes must be made to
sysv4.h:

echo -en '\n#undef STANDARD_STARTFILE_PREFIX_1\n#define STANDARD_STARTFILE_PREFIX_1 "/tools/lib/"\n' >> gcc/config/rs6000/sysv4.h
echo -en '\n#undef STANDARD_STARTFILE_PREFIX_2\n#define STANDARD_STARTFILE_PREFIX_2 ""\n' >> gcc/config/rs6000/sysv4.h